### PR TITLE
Fix newline handling to prevent mixed line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# Set default behavior to automatically normalize line endings
+* text=auto eol=lf
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout
+*.json text eol=lf
+*.sql text eol=lf
+*.html text eol=lf
+*.css text eol=lf
+*.js text eol=lf
+*.py text eol=lf
+*.md text eol=lf
+*.txt text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# Denote all files that are truly binary and should not be modified
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary

--- a/extract_literals.py
+++ b/extract_literals.py
@@ -9,6 +9,9 @@ Usage:
     python extract_literals.py extract [file_pattern]  # Extract literals to separate files
     python extract_literals.py rebuild [file_pattern]  # Rebuild JSON from extracted files
     python extract_literals.py check [file_pattern]    # Check if extracted files are in sync
+
+Options:
+    --normalize-newlines    Convert all files to Unix-style newlines (LF)
 """
 
 import glob
@@ -17,7 +20,26 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
+
+
+def detect_newline_style(content: str) -> str:
+    """Detect the predominant newline style in content."""
+    if not content:
+        return '\n'  # Default to Unix style
+    
+    # Count different newline types
+    crlf_count = content.count('\r\n')
+    lf_count = content.count('\n') - crlf_count  # Subtract CRLF occurrences
+    cr_count = content.count('\r') - crlf_count  # Subtract CRLF occurrences
+    
+    # Return the most common style
+    if crlf_count > max(lf_count, cr_count):
+        return '\r\n'
+    elif cr_count > lf_count:
+        return '\r'
+    else:
+        return '\n'
 
 
 def get_file_extension(content: str, component_name: str) -> str:
@@ -43,18 +65,31 @@ def get_file_extension(content: str, component_name: str) -> str:
     return ".html"
 
 
-def extract_literals_from_json(json_file: str, output_dir: str) -> Dict[str, Any]:
+def extract_literals_from_json(json_file: str, output_dir: str, normalize_newlines: bool = False) -> Dict[str, Any]:
     """Extract literal components from a JSON file into separate files."""
 
-    with open(json_file, encoding="utf-8") as f:
-        data = json.load(f)
+    # Read the entire file to detect newline style
+    with open(json_file, 'rb') as f:
+        raw_content = f.read()
+    
+    # Decode and detect newline style
+    text_content = raw_content.decode('utf-8')
+    detected_newline = detect_newline_style(text_content)
+    
+    # Parse JSON
+    data = json.loads(text_content)
 
     page_name = data.get("constantName", Path(json_file).stem)
     page_dir = Path(output_dir) / page_name
     page_dir.mkdir(parents=True, exist_ok=True)
 
     # Track extracted literals for rebuilding
-    extraction_map = {"source_file": json_file, "page_name": page_name, "literals": []}
+    extraction_map = {
+        "source_file": json_file,
+        "page_name": page_name,
+        "literals": [],
+        "newline_style": detected_newline if not normalize_newlines else '\n'
+    }
 
     def extract_from_components(components: List[Dict], path: str = ""):
         """Recursively extract literals from components."""
@@ -70,9 +105,14 @@ def extract_literals_from_json(json_file: str, output_dir: str) -> Dict[str, Any
                     filename = f"{name}{ext}"
                     filepath = page_dir / filename
 
-                    # Write the content to file
-                    with open(filepath, "w", encoding="utf-8") as f:
-                        f.write(content)
+                    # Normalize newlines if requested
+                    if normalize_newlines:
+                        # Normalize all types of newlines to Unix style
+                        content = content.replace('\r\n', '\n').replace('\r', '\n')
+                    
+                    # Write the content to file preserving newline style
+                    with open(filepath, 'wb') as f:
+                        f.write(content.encode('utf-8'))
 
                     # Store mapping for rebuilding
                     extraction_map["literals"].append(
@@ -119,17 +159,23 @@ def rebuild_json_from_literals(page_dir: str) -> str:
 
     source_file = extraction_map["source_file"]
 
-    # Load original JSON
-    with open(source_file, encoding="utf-8") as f:
-        data = json.load(f)
+    # Load original JSON preserving format
+    with open(source_file, 'rb') as f:
+        raw_content = f.read()
+    
+    text_content = raw_content.decode('utf-8')
+    data = json.loads(text_content)
+    
+    # Get the newline style to use
+    newline_style = extraction_map.get('newline_style', '\n')
 
     # Read extracted content back
     literal_content = {}
     for literal_info in extraction_map["literals"]:
         filepath = page_path / literal_info["filename"]
         if filepath.exists():
-            with open(filepath, encoding="utf-8") as f:
-                content = f.read()
+            with open(filepath, 'rb') as f:
+                content = f.read().decode('utf-8')
                 literal_content[literal_info["component_path"]] = content
 
     def update_components(components: List[Dict], path: str = ""):
@@ -150,9 +196,15 @@ def rebuild_json_from_literals(page_dir: str) -> str:
     if "modelView" in data and "components" in data["modelView"]:
         update_components(data["modelView"]["components"])
 
-    # Write updated JSON back
-    with open(source_file, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=3, ensure_ascii=False)
+    # Write updated JSON back with proper newline handling
+    json_str = json.dumps(data, indent=3, ensure_ascii=False)
+    
+    # Convert newlines to match the original file's style
+    if newline_style != '\n':
+        json_str = json_str.replace('\n', newline_style)
+    
+    with open(source_file, 'wb') as f:
+        f.write(json_str.encode('utf-8'))
 
     print(f"Rebuilt: {source_file}")
     return source_file
@@ -214,8 +266,8 @@ def check_sync_status(page_dir: str) -> bool:
             all_synced = False
             continue
 
-        with open(filepath, encoding="utf-8") as f:
-            file_content = f.read()
+        with open(filepath, 'rb') as f:
+            file_content = f.read().decode('utf-8')
 
         json_content = current_content.get(component_path, "")
 
@@ -236,6 +288,12 @@ def main():
         sys.exit(1)
 
     command = sys.argv[1]
+    
+    # Check for --normalize-newlines flag
+    normalize_newlines = '--normalize-newlines' in sys.argv
+    if normalize_newlines:
+        sys.argv.remove('--normalize-newlines')
+    
     pattern = sys.argv[2] if len(sys.argv) > 2 else "**/*.json"
 
     # Find JSON files matching pattern
@@ -263,7 +321,7 @@ def main():
         print(f"Extracting literals from {len(json_files)} files...")
         for json_file in json_files:
             print(f"\nProcessing: {json_file}")
-            extract_literals_from_json(json_file, output_dir)
+            extract_literals_from_json(json_file, output_dir, normalize_newlines)
 
         print(f"\n✅ Extraction complete! Files saved to: {output_dir}")
         print("You can now edit the extracted HTML/CSS/JS files directly.")

--- a/extract_virtual_domains.py
+++ b/extract_virtual_domains.py
@@ -9,6 +9,9 @@ Usage:
     python extract_virtual_domains.py extract [file_pattern]  # Extract SQL to separate files
     python extract_virtual_domains.py rebuild [file_pattern]  # Rebuild JSON from extracted files
     python extract_virtual_domains.py check [file_pattern]    # Check if extracted files are in sync
+
+Options:
+    --normalize-newlines    Convert all files to Unix-style newlines (LF)
 """
 
 import glob
@@ -17,14 +20,41 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 
-def extract_sql_from_json(json_file: str, output_dir: str) -> Dict[str, Any]:
+def detect_newline_style(content: str) -> str:
+    """Detect the predominant newline style in content."""
+    if not content:
+        return '\n'  # Default to Unix style
+    
+    # Count different newline types
+    crlf_count = content.count('\r\n')
+    lf_count = content.count('\n') - crlf_count  # Subtract CRLF occurrences
+    cr_count = content.count('\r') - crlf_count  # Subtract CRLF occurrences
+    
+    # Return the most common style
+    if crlf_count > max(lf_count, cr_count):
+        return '\r\n'
+    elif cr_count > lf_count:
+        return '\r'
+    else:
+        return '\n'
+
+
+def extract_sql_from_json(json_file: str, output_dir: str, normalize_newlines: bool = False) -> Dict[str, Any]:
     """Extract SQL code blocks from a virtual domain JSON file into separate .sql files."""
 
-    with open(json_file, encoding="utf-8") as f:
-        data = json.load(f)
+    # Read the entire file to detect newline style
+    with open(json_file, 'rb') as f:
+        raw_content = f.read()
+    
+    # Decode and detect newline style
+    text_content = raw_content.decode('utf-8')
+    detected_newline = detect_newline_style(text_content)
+    
+    # Parse JSON
+    data = json.loads(text_content)
 
     service_name = data.get(
         "serviceName", Path(json_file).stem.replace("virtualDomains.", "")
@@ -37,6 +67,7 @@ def extract_sql_from_json(json_file: str, output_dir: str) -> Dict[str, Any]:
         "source_file": json_file,
         "service_name": service_name,
         "sql_blocks": [],
+        "newline_style": detected_newline if not normalize_newlines else '\n'
     }
 
     # SQL code fields that might contain extractable content
@@ -45,22 +76,23 @@ def extract_sql_from_json(json_file: str, output_dir: str) -> Dict[str, Any]:
     for field in sql_fields:
         sql_content = data.get(field)
         if sql_content and sql_content.strip():
-            # Clean up common SQL formatting issues from Banner exports
-            cleaned_content = sql_content.replace("\r\n", "\n").replace("\r", "\n")
+            # Normalize newlines if requested
+            if normalize_newlines:
+                sql_content = sql_content.replace("\r\n", "\n").replace("\r", "\n")
 
             filename = f"{field.lower()}.sql"
             filepath = domain_dir / filename
 
-            # Write the SQL content to file
-            with open(filepath, "w", encoding="utf-8") as f:
-                f.write(cleaned_content)
+            # Write the SQL content to file preserving newline style
+            with open(filepath, 'wb') as f:
+                f.write(sql_content.encode('utf-8'))
 
             # Store mapping for rebuilding
             extraction_map["sql_blocks"].append(
                 {
                     "field": field,
                     "filename": filename,
-                    "content_hash": hashlib.md5(cleaned_content.encode()).hexdigest(),
+                    "content_hash": hashlib.md5(sql_content.encode()).hexdigest(),
                 }
             )
 
@@ -93,22 +125,34 @@ def rebuild_json_from_sql(domain_dir: str) -> str:
 
     source_file = extraction_map["source_file"]
 
-    # Load original JSON
-    with open(source_file, encoding="utf-8") as f:
-        data = json.load(f)
+    # Load original JSON preserving format
+    with open(source_file, 'rb') as f:
+        raw_content = f.read()
+    
+    text_content = raw_content.decode('utf-8')
+    data = json.loads(text_content)
+    
+    # Get the newline style to use
+    newline_style = extraction_map.get('newline_style', '\n')
 
     # Read extracted SQL content back
     for sql_info in extraction_map["sql_blocks"]:
         filepath = domain_path / sql_info["filename"]
         if filepath.exists():
-            with open(filepath, encoding="utf-8") as f:
-                content = f.read()
+            with open(filepath, 'rb') as f:
+                content = f.read().decode('utf-8')
                 # Update the JSON with the file content
                 data[sql_info["field"]] = content
 
-    # Write updated JSON back
-    with open(source_file, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
+    # Write updated JSON back with proper newline handling
+    json_str = json.dumps(data, indent=2, ensure_ascii=False)
+    
+    # Convert newlines to match the original file's style
+    if newline_style != '\n':
+        json_str = json_str.replace('\n', newline_style)
+    
+    with open(source_file, 'wb') as f:
+        f.write(json_str.encode('utf-8'))
 
     print(f"Rebuilt: {source_file}")
     return source_file
@@ -148,8 +192,8 @@ def check_sync_status(domain_dir: str) -> bool:
             all_synced = False
             continue
 
-        with open(filepath, encoding="utf-8") as f:
-            file_content = f.read()
+        with open(filepath, 'rb') as f:
+            file_content = f.read().decode('utf-8')
 
         json_content = data.get(field, "")
 
@@ -178,6 +222,12 @@ def main():
         sys.exit(1)
 
     command = sys.argv[1]
+    
+    # Check for --normalize-newlines flag
+    normalize_newlines = '--normalize-newlines' in sys.argv
+    if normalize_newlines:
+        sys.argv.remove('--normalize-newlines')
+    
     pattern = sys.argv[2] if len(sys.argv) > 2 else "**/*.json"
 
     # Find virtual domain JSON files matching pattern
@@ -209,7 +259,7 @@ def main():
         print(f"Extracting SQL from {len(json_files)} virtual domain files...")
         for json_file in json_files:
             print(f"\nProcessing: {json_file}")
-            extract_sql_from_json(json_file, output_dir)
+            extract_sql_from_json(json_file, output_dir, normalize_newlines)
 
         print(f"\n✅ Extraction complete! Files saved to: {output_dir}")
         print("You can now edit the extracted .sql files directly.")

--- a/extracted_literals/efgByStu/_extraction_map.json
+++ b/extracted_literals/efgByStu/_extraction_map.json
@@ -32,5 +32,6 @@
       "filename": "js.js",
       "content_hash": "1c21703a9b55e7df5719f30189ed5113"
     }
-  ]
+  ],
+  "newline_style": "\n"
 }

--- a/extracted_literals/ftReview/_extraction_map.json
+++ b/extracted_literals/ftReview/_extraction_map.json
@@ -32,5 +32,6 @@
       "filename": "js.js",
       "content_hash": "c9396ad12648752ab9414f0d911ebbe4"
     }
-  ]
+  ],
+  "newline_style": "\n"
 }

--- a/extracted_literals/name-coach-v3/_extraction_map.json
+++ b/extracted_literals/name-coach-v3/_extraction_map.json
@@ -14,5 +14,6 @@
       "filename": "main_literal.js",
       "content_hash": "83c183078a1b1d7fcdfdca2596d93998"
     }
-  ]
+  ],
+  "newline_style": "\n"
 }

--- a/extracted_literals/name-coach/_extraction_map.json
+++ b/extracted_literals/name-coach/_extraction_map.json
@@ -20,5 +20,6 @@
       "filename": "functions.js",
       "content_hash": "c17cd6cb6b56182cc9daf8c6812102e4"
     }
-  ]
+  ],
+  "newline_style": "\n"
 }

--- a/extracted_virtual_domains/spridenName/_extraction_map.json
+++ b/extracted_virtual_domains/spridenName/_extraction_map.json
@@ -7,5 +7,6 @@
       "filename": "codeget.sql",
       "content_hash": "cda98c83ae07382d7e3c03cd65ce0052"
     }
-  ]
+  ],
+  "newline_style": "\n"
 }

--- a/tests/test_newline_handling.py
+++ b/tests/test_newline_handling.py
@@ -1,0 +1,337 @@
+"""Test newline handling in extract scripts to prevent mixed line ending issues."""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Add parent directory to path to import the scripts
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from extract_literals import detect_newline_style, extract_literals_from_json, rebuild_json_from_literals
+from extract_virtual_domains import extract_sql_from_json, rebuild_json_from_sql
+
+
+class TestNewlineDetection:
+    """Test the newline detection functionality."""
+    
+    def test_detect_unix_newlines(self):
+        """Test detection of Unix-style newlines."""
+        content = "Line 1\nLine 2\nLine 3\n"
+        assert detect_newline_style(content) == '\n'
+    
+    def test_detect_windows_newlines(self):
+        """Test detection of Windows-style newlines."""
+        content = "Line 1\r\nLine 2\r\nLine 3\r\n"
+        assert detect_newline_style(content) == '\r\n'
+    
+    def test_detect_mac_newlines(self):
+        """Test detection of old Mac-style newlines."""
+        content = "Line 1\rLine 2\rLine 3\r"
+        assert detect_newline_style(content) == '\r'
+    
+    def test_detect_mixed_newlines_unix_dominant(self):
+        """Test detection when Unix newlines are dominant."""
+        content = "Line 1\nLine 2\nLine 3\r\nLine 4\n"
+        assert detect_newline_style(content) == '\n'
+    
+    def test_detect_mixed_newlines_windows_dominant(self):
+        """Test detection when Windows newlines are dominant."""
+        content = "Line 1\r\nLine 2\r\nLine 3\nLine 4\r\n"
+        assert detect_newline_style(content) == '\r\n'
+    
+    def test_detect_empty_content(self):
+        """Test detection with empty content."""
+        assert detect_newline_style("") == '\n'
+
+
+class TestLiteralsNewlinePreservation:
+    """Test that extract_literals preserves newlines correctly."""
+    
+    @pytest.fixture
+    def sample_page_unix(self, tmp_path):
+        """Create a sample page JSON with Unix newlines."""
+        page_data = {
+            "constantName": "testPage",
+            "modelView": {
+                "components": [
+                    {
+                        "type": "literal",
+                        "name": "test_content",
+                        "value": "<div>\n  <h1>Test</h1>\n  <p>Content</p>\n</div>"
+                    }
+                ]
+            }
+        }
+        
+        json_file = tmp_path / "page.unix.json"
+        # Write with Unix newlines
+        with open(json_file, 'w', newline='') as f:
+            json.dump(page_data, f, indent=2)
+        
+        return json_file
+    
+    @pytest.fixture
+    def sample_page_windows(self, tmp_path):
+        """Create a sample page JSON with Windows newlines."""
+        page_data = {
+            "constantName": "testPage",
+            "modelView": {
+                "components": [
+                    {
+                        "type": "literal",
+                        "name": "test_content",
+                        "value": "<div>\r\n  <h1>Test</h1>\r\n  <p>Content</p>\r\n</div>"
+                    }
+                ]
+            }
+        }
+        
+        json_file = tmp_path / "page.windows.json"
+        # Write with Windows newlines
+        json_str = json.dumps(page_data, indent=2)
+        json_str = json_str.replace('\n', '\r\n')
+        with open(json_file, 'wb') as f:
+            f.write(json_str.encode('utf-8'))
+        
+        return json_file
+    
+    def test_preserve_unix_newlines(self, sample_page_unix, tmp_path):
+        """Test that Unix newlines are preserved during extract/rebuild."""
+        output_dir = tmp_path / "extracted"
+        
+        # Extract
+        extract_literals_from_json(str(sample_page_unix), str(output_dir))
+        
+        # Check extracted file has Unix newlines
+        extracted_file = output_dir / "testPage" / "test_content.html"
+        with open(extracted_file, 'rb') as f:
+            content = f.read()
+        
+        assert b'\r\n' not in content  # No Windows newlines
+        assert b'\n' in content  # Has Unix newlines
+        
+        # Rebuild
+        rebuild_json_from_literals(str(output_dir / "testPage"))
+        
+        # Check JSON still has Unix newlines
+        with open(sample_page_unix, 'rb') as f:
+            rebuilt_content = f.read()
+        
+        assert b'\r\n' not in rebuilt_content
+        assert b'\n' in rebuilt_content
+    
+    def test_preserve_windows_newlines(self, sample_page_windows, tmp_path):
+        """Test that Windows newlines are preserved during extract/rebuild."""
+        output_dir = tmp_path / "extracted"
+        
+        # Extract
+        extract_literals_from_json(str(sample_page_windows), str(output_dir))
+        
+        # Check extraction map recorded Windows newlines
+        map_file = output_dir / "testPage" / "_extraction_map.json"
+        with open(map_file) as f:
+            extraction_map = json.load(f)
+        assert extraction_map['newline_style'] == '\r\n'
+        
+        # Rebuild
+        rebuild_json_from_literals(str(output_dir / "testPage"))
+        
+        # Check JSON still has Windows newlines
+        with open(sample_page_windows, 'rb') as f:
+            rebuilt_content = f.read()
+        
+        assert b'\r\n' in rebuilt_content
+    
+    def test_normalize_newlines_option(self, sample_page_windows, tmp_path):
+        """Test that --normalize-newlines converts to Unix style."""
+        output_dir = tmp_path / "extracted"
+        
+        # Extract with normalization
+        extract_literals_from_json(str(sample_page_windows), str(output_dir), normalize_newlines=True)
+        
+        # Check extracted file has Unix newlines
+        extracted_file = output_dir / "testPage" / "test_content.html"
+        with open(extracted_file, 'rb') as f:
+            content = f.read()
+        
+        assert b'\r\n' not in content  # No Windows newlines
+        assert b'\n' in content  # Has Unix newlines
+        
+        # Check extraction map records Unix style
+        map_file = output_dir / "testPage" / "_extraction_map.json"
+        with open(map_file) as f:
+            extraction_map = json.load(f)
+        assert extraction_map['newline_style'] == '\n'
+
+
+class TestVirtualDomainsNewlinePreservation:
+    """Test that extract_virtual_domains preserves newlines correctly."""
+    
+    @pytest.fixture
+    def sample_vd_windows(self, tmp_path):
+        """Create a sample virtual domain JSON with Windows newlines and SQL."""
+        vd_data = {
+            "serviceName": "testService",
+            "codeGet": "SELECT *\r\nFROM test_table\r\nWHERE id = :id"
+        }
+        
+        json_file = tmp_path / "virtualDomain.windows.json"
+        # Write with Windows newlines
+        json_str = json.dumps(vd_data, indent=2)
+        json_str = json_str.replace('\n', '\r\n')
+        with open(json_file, 'wb') as f:
+            f.write(json_str.encode('utf-8'))
+        
+        return json_file
+    
+    def test_vd_preserve_windows_newlines(self, sample_vd_windows, tmp_path):
+        """Test that Windows newlines in SQL are preserved."""
+        output_dir = tmp_path / "extracted_vd"
+        
+        # Extract
+        extract_sql_from_json(str(sample_vd_windows), str(output_dir))
+        
+        # Check SQL file content
+        sql_file = output_dir / "testService" / "codeget.sql"
+        with open(sql_file, 'rb') as f:
+            content = f.read().decode('utf-8')
+        
+        # SQL content should be preserved as-is
+        assert "SELECT *\r\nFROM test_table\r\nWHERE id = :id" in content
+        
+        # Rebuild
+        rebuild_json_from_sql(str(output_dir / "testService"))
+        
+        # Check JSON still has Windows newlines
+        with open(sample_vd_windows, 'rb') as f:
+            rebuilt_content = f.read()
+        
+        assert b'\r\n' in rebuilt_content
+    
+    def test_vd_normalize_newlines(self, sample_vd_windows, tmp_path):
+        """Test normalizing SQL newlines."""
+        output_dir = tmp_path / "extracted_vd"
+        
+        # Extract with normalization
+        extract_sql_from_json(str(sample_vd_windows), str(output_dir), normalize_newlines=True)
+        
+        # Check SQL file has Unix newlines
+        sql_file = output_dir / "testService" / "codeget.sql"
+        with open(sql_file, 'rb') as f:
+            content = f.read()
+        
+        assert b'\r\n' not in content
+        assert b'\n' in content
+
+
+class TestMixedNewlineScenarios:
+    """Test handling of files with mixed newlines that could cause git issues."""
+    
+    def test_mixed_newlines_in_literals(self, tmp_path):
+        """Test handling content with accidentally mixed newlines."""
+        # Create a file that simulates what happens when Windows editors
+        # modify extracted files
+        page_data = {
+            "constantName": "mixedTest",
+            "modelView": {
+                "components": [
+                    {
+                        "type": "literal",
+                        "name": "mixed_content",
+                        # This simulates content that has been edited on different systems
+                        "value": "<div>\n  <h1>Unix line</h1>\r\n  <p>Windows line</p>\n</div>"
+                    }
+                ]
+            }
+        }
+        
+        json_file = tmp_path / "mixed.json"
+        with open(json_file, 'w') as f:
+            json.dump(page_data, f)
+        
+        output_dir = tmp_path / "extracted"
+        
+        # Extract with normalization should fix the mixed newlines
+        extract_literals_from_json(str(json_file), str(output_dir), normalize_newlines=True)
+        
+        # Check that extracted content has consistent newlines
+        extracted_file = output_dir / "mixedTest" / "mixed_content.html"
+        with open(extracted_file, 'rb') as f:
+            content = f.read()
+        
+        # Should only have Unix newlines
+        assert b'\r\n' not in content
+        assert b'\n' in content
+        
+        # Count newlines to ensure they're all consistent
+        text = content.decode('utf-8')
+        assert '\r\n' not in text
+        assert text.count('\n') == 3  # Three line breaks in the content
+    
+    def test_detect_and_warn_mixed_newlines(self):
+        """Test that mixed newlines are properly detected."""
+        # Various mixed content scenarios
+        mixed_contents = [
+            "Unix\nWindows\r\nUnix\n",
+            "Start\r\nMiddle\nEnd\r\n",
+            "\n\r\n\n\r\n",  # Alternating
+        ]
+        
+        for content in mixed_contents:
+            style = detect_newline_style(content)
+            # Should detect the predominant style
+            assert style in ['\n', '\r\n', '\r']
+
+
+class TestRealWorldScenarios:
+    """Test scenarios that match real-world usage patterns."""
+    
+    def test_windows_developer_unix_server(self, tmp_path):
+        """Test workflow: Windows developer edits files, deploys to Unix server."""
+        # Create initial file with Unix newlines (as it would be in git)
+        page_data = {
+            "constantName": "deployment",
+            "modelView": {
+                "components": [
+                    {
+                        "type": "literal",
+                        "name": "app",
+                        "value": "#!/bin/bash\necho 'Deploy script'\nexit 0"
+                    }
+                ]
+            }
+        }
+        
+        json_file = tmp_path / "deploy.json"
+        with open(json_file, 'w', newline='') as f:
+            json.dump(page_data, f, indent=2)
+        
+        output_dir = tmp_path / "extracted"
+        
+        # Extract (preserves Unix newlines)
+        extract_literals_from_json(str(json_file), str(output_dir))
+        
+        # Simulate Windows editor changing the file
+        app_file = output_dir / "deployment" / "app.html"
+        with open(app_file, 'r') as f:
+            content = f.read()
+        
+        # Windows editor might add CRLF
+        content_windows = content.replace('\n', '\r\n')
+        with open(app_file, 'wb') as f:
+            f.write(content_windows.encode('utf-8'))
+        
+        # Rebuild should preserve the JSON's original Unix newlines
+        rebuild_json_from_literals(str(output_dir / "deployment"))
+        
+        # Verify JSON still has Unix newlines (no git changes)
+        with open(json_file, 'rb') as f:
+            final_content = f.read()
+        
+        # The JSON should maintain Unix newlines despite Windows editing
+        assert b'\r\n' not in final_content
+        assert b'\n' in final_content


### PR DESCRIPTION
- Add intelligent newline detection that preserves original file format
- Create .gitattributes to enforce consistent line endings in git
- Add --normalize-newlines option for explicit conversion to Unix style
- Update file I/O to use binary mode to prevent platform-specific conversions
- Add comprehensive tests for newline handling scenarios
- Store newline style in extraction maps for consistency

This prevents the issue where editing extracted files on Windows would introduce CRLF line endings that pollute git history when rebuilt.

🤖 Generated with [Claude Code](https://claude.ai/code)